### PR TITLE
Switch to Assembly.GetEntryAssembly() with null check

### DIFF
--- a/src/SitemapMiddleware/SitemapMiddleware.cs
+++ b/src/SitemapMiddleware/SitemapMiddleware.cs
@@ -71,7 +71,10 @@ namespace Yasl.Net.SiteMapMiddleware
                 ChangeFrequency = "daily",
                 Priority = 1.0
             });
-            var assembly = Assembly.GetExecutingAssembly();
+            var assembly = Assembly.GetEntryAssembly();
+
+            if (assembly == null)
+                return urls;
 
             var controllers = assembly.GetTypes()
                 .Where(type => typeof(Controller).IsAssignableFrom(type));


### PR DESCRIPTION
Updated the method to use Assembly.GetEntryAssembly() instead of Assembly.GetExecutingAssembly() to ensure the correct assembly is referenced, especially in plugin architectures or reflection scenarios. Added a null check for the assembly variable to prevent null reference exceptions by returning early if the entry assembly is not found.