### PR TITLE
Add sitemap options and robots.txt support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,3 +14,5 @@ jobs:
       uses: actions/checkout@v2
     - name: Build
       run: dotnet build --configuration Release
+    - name: Test
+      run: dotnet test --configuration Release --no-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
           run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
         - name: Build
           run: dotnet build --configuration Release /p:Version=${VERSION}
+        - name: Test
+          run: dotnet test --configuration Release --no-build
         - name: Pack
           run: dotnet pack --configuration Release /p:Version=${VERSION} --no-build --output .
         - name: Push

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ SitemapMiddleware is a middleware component for generating and serving sitemaps 
 ## Features
 
 - Automatically generates sitemaps for your web application.
+- Optionally serves robots.txt with a sitemap directive.
 - Easy integration with existing web frameworks.
 
 ## Installation
@@ -18,12 +19,31 @@ dotnet add package Yasl.Net.SitemapMiddleware
 ## Usage
 
 To use this middleware, add it to the request pipeline in the Startup.cs file:
+
 ```csharp
 public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 {
-    app.UseMiddleware<SitemapMiddleware>("https://example.com");
+    app.UseSitemapMiddleware("https://example.com", options =>
+    {
+        options.ServeRobotsTxt = true;
+        options.RobotsTxtAdditionalLines.Add("Clean-param: etext");
+    });
+
     // other middlewares
 }
+```
+
+This serves:
+
+- `/sitemap.xml`
+- `/robots.txt` when `ServeRobotsTxt` is enabled
+
+The root URL must be an absolute `http` or `https` URL. File URLs and empty values are rejected.
+
+The legacy registration style is still supported:
+
+```csharp
+app.UseMiddleware<SitemapMiddleware>("https://example.com");
 ```
 
 ## Contributing

--- a/SitemapMiddleware.sln
+++ b/SitemapMiddleware.sln
@@ -5,7 +5,11 @@ VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{704BBF9B-E783-4FA3-AC57-953439478FB8}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{211689C3-35E8-4F0E-A6C5-D3796FAD6F41}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SitemapMiddleware", "src\SitemapMiddleware\SitemapMiddleware.csproj", "{D69E7D42-1882-4D94-AD48-523A1A1D73C0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SitemapMiddleware.Tests", "tests\SitemapMiddleware.Tests\SitemapMiddleware.Tests.csproj", "{75866659-9396-4375-88BD-9FB009903A27}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,12 +21,17 @@ Global
 		{D69E7D42-1882-4D94-AD48-523A1A1D73C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D69E7D42-1882-4D94-AD48-523A1A1D73C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D69E7D42-1882-4D94-AD48-523A1A1D73C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75866659-9396-4375-88BD-9FB009903A27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75866659-9396-4375-88BD-9FB009903A27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75866659-9396-4375-88BD-9FB009903A27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75866659-9396-4375-88BD-9FB009903A27}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{D69E7D42-1882-4D94-AD48-523A1A1D73C0} = {704BBF9B-E783-4FA3-AC57-953439478FB8}
+		{75866659-9396-4375-88BD-9FB009903A27} = {211689C3-35E8-4F0E-A6C5-D3796FAD6F41}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {97AD131D-827C-491F-A66A-A5C9816B11A7}

--- a/src/SitemapMiddleware/SitemapMiddleware.cs
+++ b/src/SitemapMiddleware/SitemapMiddleware.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -27,7 +28,11 @@ namespace Yasl.Net.SiteMapMiddleware
     public class SitemapMiddleware
     {
         private readonly RequestDelegate _next;
+        private readonly SitemapMiddlewareOptions _options;
+        private readonly Uri _rootUri;
         private readonly string _rootUrl;
+        private readonly string _sitemapPath;
+        private readonly string _robotsPath;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SitemapMiddleware"/> class.
@@ -36,9 +41,23 @@ namespace Yasl.Net.SiteMapMiddleware
         /// <param name="rootUrl">The root URL of the application.</param>
         /// 
         public SitemapMiddleware(RequestDelegate next, string rootUrl)
+            : this(next, new SitemapMiddlewareOptions { RootUrl = rootUrl })
         {
-            _next = next;
-            _rootUrl = rootUrl.TrimEnd('/');
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SitemapMiddleware"/> class.
+        /// </summary>
+        /// <param name="next">The next middleware in the request pipeline.</param>
+        /// <param name="options">Options for sitemap and robots.txt generation.</param>
+        public SitemapMiddleware(RequestDelegate next, SitemapMiddlewareOptions options)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _rootUri = _options.GetRootUri();
+            _rootUrl = _rootUri.ToString().TrimEnd('/');
+            _sitemapPath = SitemapMiddlewareOptions.NormalizeRequestPath(_options.SitemapPath, nameof(_options.SitemapPath));
+            _robotsPath = SitemapMiddlewareOptions.NormalizeRequestPath(_options.RobotsPath, nameof(_options.RobotsPath));
         }
 
         /// <summary>
@@ -48,17 +67,55 @@ namespace Yasl.Net.SiteMapMiddleware
         /// <returns></returns>
         public async Task InvokeAsync(HttpContext context)
         {
-            if (context.Request.Path.Value?.ToLower() == "/sitemap.xml")
+            var requestPath = context.Request.Path.Value;
+            if (string.Equals(requestPath, _sitemapPath, StringComparison.OrdinalIgnoreCase))
             {
                 var urls = GenerateSitemapUrls();
                 var sitemapXml = GenerateSitemapXml(urls);
 
                 context.Response.ContentType = "application/xml";
+                SetCacheHeaders(context);
                 await context.Response.WriteAsync(sitemapXml);
                 return;
             }
 
+            if (_options.ServeRobotsTxt &&
+                string.Equals(requestPath, _robotsPath, StringComparison.OrdinalIgnoreCase))
+            {
+                context.Response.ContentType = "text/plain; charset=utf-8";
+                SetCacheHeaders(context);
+                await context.Response.WriteAsync(GenerateRobotsTxt());
+                return;
+            }
+
             await _next(context);
+        }
+
+        private void SetCacheHeaders(HttpContext context)
+        {
+            if (_options.CacheMaxAgeSeconds > 0)
+            {
+                context.Response.Headers["Cache-Control"] = $"public,max-age={_options.CacheMaxAgeSeconds}";
+            }
+        }
+
+        private string GenerateRobotsTxt()
+        {
+            var builder = new StringBuilder()
+                .AppendLine("User-agent: *");
+
+            foreach (var line in _options.RobotsTxtAdditionalLines)
+            {
+                if (!string.IsNullOrWhiteSpace(line))
+                {
+                    builder.AppendLine(line.Trim());
+                }
+            }
+
+            return builder
+                .Append("Sitemap: ")
+                .Append(BuildAbsoluteUrl(_sitemapPath))
+                .ToString();
         }
 
         private List<SitemapUrl> GenerateSitemapUrls()
@@ -99,20 +156,20 @@ namespace Yasl.Net.SiteMapMiddleware
 
                         urls.Add(new SitemapUrl
                         {
-                            Location = $"{_rootUrl}/{url}",
+                            Location = BuildAbsoluteUrl(url),
                             LastModified = DateTime.UtcNow,
                             ChangeFrequency = attr?.ChangeFreq ?? "daily",
                             Priority = attr?.Priority ?? 0.5,
                             Images = imageAttributes.Select(img => new SitemapImage
                             {
-                                Location = img.ImageUrl.StartsWith("http") ? img.ImageUrl : $"{_rootUrl}/{img.ImageUrl.TrimStart('/')}",
+                                Location = BuildAbsoluteUrl(img.ImageUrl),
                                 Title = img.Title,
                                 Caption = img.Caption,
                                 License = img.License
                             }).ToList(),
                             Videos = videoAttributes.Select(video => new SitemapVideo
                             {
-                                ThumbnailUrl = video.ThumbnailUrl.StartsWith("http") ? video.ThumbnailUrl : $"{_rootUrl}/{video.ThumbnailUrl.TrimStart('/')}",
+                                ThumbnailUrl = BuildAbsoluteUrl(video.ThumbnailUrl),
                                 Title = video.Title,
                                 Description = video.Description,
                                 ContentUrl = video.ContentUrl,
@@ -143,6 +200,33 @@ namespace Yasl.Net.SiteMapMiddleware
             return $"{controllerName}/{actionName}";
         }
 
+        private string BuildAbsoluteUrl(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return _rootUrl;
+            }
+
+            var normalized = value.Trim();
+            if (normalized.StartsWith("/", StringComparison.Ordinal))
+            {
+                return new Uri(_rootUri, normalized.TrimStart('/')).ToString();
+            }
+
+            if (Uri.TryCreate(normalized, UriKind.Absolute, out var absolute))
+            {
+                if (!string.Equals(absolute.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+                    !string.Equals(absolute.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new ArgumentException("Sitemap URLs must use http or https.", nameof(value));
+                }
+
+                return absolute.ToString();
+            }
+
+            return new Uri(_rootUri, normalized).ToString();
+        }
+
         private string GenerateSitemapXml(List<SitemapUrl> urls)
         {
             var xmlns = "http://www.sitemaps.org/schemas/sitemap/0.9";
@@ -160,7 +244,6 @@ namespace Yasl.Net.SiteMapMiddleware
                             new XElement(XName.Get("lastmod", xmlns), url.LastModified.ToString("yyyy-MM-dd")),
                             new XElement(XName.Get("changefreq", xmlns), url.ChangeFrequency),
                             new XElement(XName.Get("priority", xmlns), url.Priority.ToString("0.0", System.Globalization.CultureInfo.InvariantCulture)),
-                            // Изображения
                             url.Images.Select(img =>
                                 new XElement(XName.Get("image", imageXmlns),
                                     new XElement(XName.Get("loc", imageXmlns), img.Location),
@@ -169,7 +252,6 @@ namespace Yasl.Net.SiteMapMiddleware
                                     img.License != null ? new XElement(XName.Get("license", imageXmlns), img.License) : null
                                 )
                             ),
-                            // Видео
                             url.Videos.Select(video =>
                                 new XElement(XName.Get("video", videoXmlns),
                                     new XElement(XName.Get("thumbnail_loc", videoXmlns), video.ThumbnailUrl),

--- a/src/SitemapMiddleware/SitemapMiddleware.csproj
+++ b/src/SitemapMiddleware/SitemapMiddleware.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Yasl.Net.SitemapMiddleware</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Sergey Yazovskiy</Authors>
     <Description>A middleware for generating sitemaps</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/SitemapMiddleware/SitemapMiddlewareExtensions.cs
+++ b/src/SitemapMiddleware/SitemapMiddlewareExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Builder;
+
+namespace Yasl.Net.SiteMapMiddleware
+{
+    /// <summary>
+    /// Registration helpers for <see cref="SitemapMiddleware"/>.
+    /// </summary>
+    public static class SitemapMiddlewareExtensions
+    {
+        /// <summary>
+        /// Adds sitemap and optional robots.txt generation to the application pipeline.
+        /// </summary>
+        public static IApplicationBuilder UseSitemapMiddleware(
+            this IApplicationBuilder app,
+            string rootUrl,
+            Action<SitemapMiddlewareOptions>? configure = null)
+        {
+            ArgumentNullException.ThrowIfNull(app);
+
+            var options = new SitemapMiddlewareOptions
+            {
+                RootUrl = rootUrl
+            };
+
+            configure?.Invoke(options);
+            return app.UseMiddleware<SitemapMiddleware>(options);
+        }
+    }
+}

--- a/src/SitemapMiddleware/SitemapMiddlewareOptions.cs
+++ b/src/SitemapMiddleware/SitemapMiddlewareOptions.cs
@@ -1,0 +1,72 @@
+namespace Yasl.Net.SiteMapMiddleware
+{
+    /// <summary>
+    /// Options used by <see cref="SitemapMiddleware"/>.
+    /// </summary>
+    public sealed class SitemapMiddlewareOptions
+    {
+        /// <summary>
+        /// Absolute root URL of the application.
+        /// </summary>
+        public string RootUrl { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Request path used to serve the sitemap document.
+        /// </summary>
+        public string SitemapPath { get; set; } = "/sitemap.xml";
+
+        /// <summary>
+        /// Enables robots.txt generation.
+        /// </summary>
+        public bool ServeRobotsTxt { get; set; }
+
+        /// <summary>
+        /// Request path used to serve robots.txt.
+        /// </summary>
+        public string RobotsPath { get; set; } = "/robots.txt";
+
+        /// <summary>
+        /// Additional robots.txt directives emitted after User-agent.
+        /// </summary>
+        public IList<string> RobotsTxtAdditionalLines { get; } = new List<string>();
+
+        /// <summary>
+        /// Public cache duration for generated metadata responses.
+        /// </summary>
+        public int CacheMaxAgeSeconds { get; set; } = 3600;
+
+        internal Uri GetRootUri()
+        {
+            var normalized = (RootUrl ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                throw new ArgumentException("RootUrl must be configured.", nameof(RootUrl));
+            }
+
+            normalized = normalized.TrimEnd('/') + "/";
+            if (!Uri.TryCreate(normalized, UriKind.Absolute, out var uri))
+            {
+                throw new ArgumentException("RootUrl must be an absolute URI.", nameof(RootUrl));
+            }
+
+            if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("RootUrl must use http or https.", nameof(RootUrl));
+            }
+
+            return uri;
+        }
+
+        internal static string NormalizeRequestPath(string path, string parameterName)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException($"{parameterName} must be configured.", parameterName);
+            }
+
+            var trimmed = path.Trim();
+            return trimmed.StartsWith("/", StringComparison.Ordinal) ? trimmed : "/" + trimmed;
+        }
+    }
+}

--- a/tests/SitemapMiddleware.Tests/SitemapMiddleware.Tests.csproj
+++ b/tests/SitemapMiddleware.Tests/SitemapMiddleware.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/SitemapMiddleware/SitemapMiddleware.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/SitemapMiddleware.Tests/SitemapMiddlewareTests.cs
+++ b/tests/SitemapMiddleware.Tests/SitemapMiddlewareTests.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Yasl.Net.SiteMapMiddleware;
+using Xunit;
+
+namespace SitemapMiddleware.Tests;
+
+public class SitemapMiddlewareTests
+{
+    [Fact]
+    public async Task SitemapXml_ReturnsAbsoluteHttpUrls()
+    {
+        var context = CreateContext("/sitemap.xml");
+        var middleware = new Yasl.Net.SiteMapMiddleware.SitemapMiddleware(
+            _ => throw new InvalidOperationException("Next middleware should not be called."),
+            "https://example.com");
+
+        await middleware.InvokeAsync(context);
+
+        var body = await ReadBodyAsync(context);
+        Assert.Equal("application/xml", context.Response.ContentType);
+        Assert.Equal("public,max-age=3600", context.Response.Headers["Cache-Control"]);
+        Assert.Contains("<loc>https://example.com</loc>", body);
+        Assert.DoesNotContain("file://", body);
+    }
+
+    [Fact]
+    public async Task RobotsTxt_IsNotIntercepted_WhenDisabled()
+    {
+        var context = CreateContext("/robots.txt");
+        var nextCalled = false;
+        var middleware = new Yasl.Net.SiteMapMiddleware.SitemapMiddleware(
+            _ =>
+            {
+                nextCalled = true;
+                return Task.CompletedTask;
+            },
+            new SitemapMiddlewareOptions
+            {
+                RootUrl = "https://example.com"
+            });
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextCalled);
+        Assert.Equal(string.Empty, await ReadBodyAsync(context));
+    }
+
+    [Fact]
+    public async Task RobotsTxt_ReturnsConfiguredDirectives_WhenEnabled()
+    {
+        var context = CreateContext("/robots.txt");
+        var options = new SitemapMiddlewareOptions
+        {
+            RootUrl = "https://example.com",
+            ServeRobotsTxt = true
+        };
+        options.RobotsTxtAdditionalLines.Add("Clean-param: etext");
+
+        var middleware = new Yasl.Net.SiteMapMiddleware.SitemapMiddleware(
+            _ => throw new InvalidOperationException("Next middleware should not be called."),
+            options);
+
+        await middleware.InvokeAsync(context);
+
+        var body = await ReadBodyAsync(context);
+        Assert.Equal("text/plain; charset=utf-8", context.Response.ContentType);
+        Assert.Equal(
+            """
+            User-agent: *
+            Clean-param: etext
+            Sitemap: https://example.com/sitemap.xml
+            """.ReplaceLineEndings("\n").TrimEnd(),
+            body.ReplaceLineEndings("\n"));
+        Assert.DoesNotContain("file://", body);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("file:///tmp/site")]
+    public void Constructor_RejectsInvalidRootUrl(string rootUrl)
+    {
+        Assert.Throws<ArgumentException>(() => new Yasl.Net.SiteMapMiddleware.SitemapMiddleware(
+            _ => Task.CompletedTask,
+            rootUrl));
+    }
+
+    private static DefaultHttpContext CreateContext(string path)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private static async Task<string> ReadBodyAsync(HttpContext context)
+    {
+        context.Response.Body.Position = 0;
+        using var reader = new StreamReader(context.Response.Body, Encoding.UTF8, leaveOpen: true);
+        return await reader.ReadToEndAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- add a public SitemapMiddlewareOptions API and UseSitemapMiddleware extension
- support optional robots.txt generation with sitemap directives
- validate root URLs as absolute http/https URLs
- add xUnit coverage and run tests in build/release workflows

## Validation
- dotnet test --configuration Release
- dotnet pack --configuration Release --no-build --output /tmp/sitemapmiddleware-pack